### PR TITLE
Fix timeout and keep-alive behaviour of http-client (Fix #3 and #4)

### DIFF
--- a/src/Atm_esp8266_httpc_simple.cpp
+++ b/src/Atm_esp8266_httpc_simple.cpp
@@ -87,12 +87,14 @@ void Atm_esp8266_httpc_simple::action( int id ) {
           response_data += (char) client.read();
         }
       }
+      if (response_data.endsWith("</html>\r\n")) client.stop();
       return;
     case ENT_DONE:
       push( connectors, ON_FINISH, 0, sub_event, 0 );
       return;
     case ENT_TIMEOUT:
       response_data = "HTTP/1.1 400 Fail\r\n";
+      push( connectors, ON_FINISH, 0, sub_event, 0 );
       return;
   }
 }


### PR DESCRIPTION
**HTTP-Client** 

Fix for #3:
  - Request timeout now calls onFinish()

Workaround for #4:
  - Close connection if client assumes that all data has been received.
  - I think this is an unclean solution, so I call it a workaround, not a fix.


